### PR TITLE
[DT-99] add recent elections to schema

### DIFF
--- a/prisma/Voter.prisma
+++ b/prisma/Voter.prisma
@@ -81,6 +81,15 @@ model Voter {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/migrations/20250605181215_add_elections_to_2026/migration.sql
+++ b/prisma/migrations/20250605181215_add_elections_to_2026/migration.sql
@@ -1,0 +1,560 @@
+-- AlterTable
+ALTER TABLE "VoterAKTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterALTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterARTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterAZTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterCATemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterCOTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterCTTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterDCTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterDETemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterFLTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterGATemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterHITemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterIATemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterIDTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterILTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterINTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterKSTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterKYTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterLATemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterMATemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterMDTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterMETemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterMITemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterMNTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterMOTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterMSTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterMTTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterNCTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterNDTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterNETemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterNHTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterNJTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterNMTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterNVTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterNYTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterOHTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterOKTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterORTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterPATemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterRITemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterSCTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterSDTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterTNTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterTXTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterUTTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterVATemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterVTTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterWATemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterWITemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterWVTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;
+
+-- AlterTable
+ALTER TABLE "VoterWYTemp" ADD COLUMN     "AnyElection_2023" TEXT,
+ADD COLUMN     "AnyElection_2025" TEXT,
+ADD COLUMN     "General_2024" TEXT,
+ADD COLUMN     "General_2026" TEXT,
+ADD COLUMN     "OtherElection_2024" TEXT,
+ADD COLUMN     "OtherElection_2026" TEXT,
+ADD COLUMN     "PresidentialPrimary_2024" TEXT,
+ADD COLUMN     "Primary_2024" TEXT,
+ADD COLUMN     "Primary_2026" TEXT;

--- a/prisma/schema/VoterAKTemp.prisma
+++ b/prisma/schema/VoterAKTemp.prisma
@@ -81,6 +81,15 @@ model VoterAKTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterALTemp.prisma
+++ b/prisma/schema/VoterALTemp.prisma
@@ -81,6 +81,15 @@ model VoterALTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterARTemp.prisma
+++ b/prisma/schema/VoterARTemp.prisma
@@ -81,6 +81,15 @@ model VoterARTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterAZTemp.prisma
+++ b/prisma/schema/VoterAZTemp.prisma
@@ -81,6 +81,15 @@ model VoterAZTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterCATemp.prisma
+++ b/prisma/schema/VoterCATemp.prisma
@@ -81,6 +81,15 @@ model VoterCATemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterCOTemp.prisma
+++ b/prisma/schema/VoterCOTemp.prisma
@@ -81,6 +81,15 @@ model VoterCOTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterCTTemp.prisma
+++ b/prisma/schema/VoterCTTemp.prisma
@@ -81,6 +81,15 @@ model VoterCTTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterDCTemp.prisma
+++ b/prisma/schema/VoterDCTemp.prisma
@@ -81,6 +81,15 @@ model VoterDCTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterDETemp.prisma
+++ b/prisma/schema/VoterDETemp.prisma
@@ -81,6 +81,15 @@ model VoterDETemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterFLTemp.prisma
+++ b/prisma/schema/VoterFLTemp.prisma
@@ -81,6 +81,15 @@ model VoterFLTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterGATemp.prisma
+++ b/prisma/schema/VoterGATemp.prisma
@@ -81,6 +81,15 @@ model VoterGATemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterHITemp.prisma
+++ b/prisma/schema/VoterHITemp.prisma
@@ -81,6 +81,15 @@ model VoterHITemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterIATemp.prisma
+++ b/prisma/schema/VoterIATemp.prisma
@@ -81,6 +81,15 @@ model VoterIATemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterIDTemp.prisma
+++ b/prisma/schema/VoterIDTemp.prisma
@@ -81,6 +81,15 @@ model VoterIDTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterILTemp.prisma
+++ b/prisma/schema/VoterILTemp.prisma
@@ -81,6 +81,15 @@ model VoterILTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterINTemp.prisma
+++ b/prisma/schema/VoterINTemp.prisma
@@ -81,6 +81,15 @@ model VoterINTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterKSTemp.prisma
+++ b/prisma/schema/VoterKSTemp.prisma
@@ -81,6 +81,15 @@ model VoterKSTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterKYTemp.prisma
+++ b/prisma/schema/VoterKYTemp.prisma
@@ -81,6 +81,15 @@ model VoterKYTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterLATemp.prisma
+++ b/prisma/schema/VoterLATemp.prisma
@@ -81,6 +81,15 @@ model VoterLATemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterMATemp.prisma
+++ b/prisma/schema/VoterMATemp.prisma
@@ -81,6 +81,15 @@ model VoterMATemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterMDTemp.prisma
+++ b/prisma/schema/VoterMDTemp.prisma
@@ -81,6 +81,15 @@ model VoterMDTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterMETemp.prisma
+++ b/prisma/schema/VoterMETemp.prisma
@@ -81,6 +81,15 @@ model VoterMETemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterMITemp.prisma
+++ b/prisma/schema/VoterMITemp.prisma
@@ -81,6 +81,15 @@ model VoterMITemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterMNTemp.prisma
+++ b/prisma/schema/VoterMNTemp.prisma
@@ -81,6 +81,15 @@ model VoterMNTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterMOTemp.prisma
+++ b/prisma/schema/VoterMOTemp.prisma
@@ -81,6 +81,15 @@ model VoterMOTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterMSTemp.prisma
+++ b/prisma/schema/VoterMSTemp.prisma
@@ -81,6 +81,15 @@ model VoterMSTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterMTTemp.prisma
+++ b/prisma/schema/VoterMTTemp.prisma
@@ -81,6 +81,15 @@ model VoterMTTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterNCTemp.prisma
+++ b/prisma/schema/VoterNCTemp.prisma
@@ -81,6 +81,15 @@ model VoterNCTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterNDTemp.prisma
+++ b/prisma/schema/VoterNDTemp.prisma
@@ -81,6 +81,15 @@ model VoterNDTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterNETemp.prisma
+++ b/prisma/schema/VoterNETemp.prisma
@@ -81,6 +81,15 @@ model VoterNETemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterNHTemp.prisma
+++ b/prisma/schema/VoterNHTemp.prisma
@@ -81,6 +81,15 @@ model VoterNHTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterNJTemp.prisma
+++ b/prisma/schema/VoterNJTemp.prisma
@@ -81,6 +81,15 @@ model VoterNJTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterNMTemp.prisma
+++ b/prisma/schema/VoterNMTemp.prisma
@@ -81,6 +81,15 @@ model VoterNMTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterNVTemp.prisma
+++ b/prisma/schema/VoterNVTemp.prisma
@@ -81,6 +81,15 @@ model VoterNVTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterNYTemp.prisma
+++ b/prisma/schema/VoterNYTemp.prisma
@@ -81,6 +81,15 @@ model VoterNYTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterOHTemp.prisma
+++ b/prisma/schema/VoterOHTemp.prisma
@@ -81,6 +81,15 @@ model VoterOHTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterOKTemp.prisma
+++ b/prisma/schema/VoterOKTemp.prisma
@@ -81,6 +81,15 @@ model VoterOKTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterORTemp.prisma
+++ b/prisma/schema/VoterORTemp.prisma
@@ -81,6 +81,15 @@ model VoterORTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterPATemp.prisma
+++ b/prisma/schema/VoterPATemp.prisma
@@ -81,6 +81,15 @@ model VoterPATemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterRITemp.prisma
+++ b/prisma/schema/VoterRITemp.prisma
@@ -81,6 +81,15 @@ model VoterRITemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterSCTemp.prisma
+++ b/prisma/schema/VoterSCTemp.prisma
@@ -81,6 +81,15 @@ model VoterSCTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterSDTemp.prisma
+++ b/prisma/schema/VoterSDTemp.prisma
@@ -81,6 +81,15 @@ model VoterSDTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterTNTemp.prisma
+++ b/prisma/schema/VoterTNTemp.prisma
@@ -81,6 +81,15 @@ model VoterTNTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterTXTemp.prisma
+++ b/prisma/schema/VoterTXTemp.prisma
@@ -81,6 +81,15 @@ model VoterTXTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterUTTemp.prisma
+++ b/prisma/schema/VoterUTTemp.prisma
@@ -81,6 +81,15 @@ model VoterUTTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterVATemp.prisma
+++ b/prisma/schema/VoterVATemp.prisma
@@ -81,6 +81,15 @@ model VoterVATemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterVTTemp.prisma
+++ b/prisma/schema/VoterVTTemp.prisma
@@ -81,6 +81,15 @@ model VoterVTTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterWATemp.prisma
+++ b/prisma/schema/VoterWATemp.prisma
@@ -81,6 +81,15 @@ model VoterWATemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterWITemp.prisma
+++ b/prisma/schema/VoterWITemp.prisma
@@ -81,6 +81,15 @@ model VoterWITemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterWVTemp.prisma
+++ b/prisma/schema/VoterWVTemp.prisma
@@ -81,6 +81,15 @@ model VoterWVTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022

--- a/prisma/schema/VoterWYTemp.prisma
+++ b/prisma/schema/VoterWYTemp.prisma
@@ -81,6 +81,15 @@ model VoterWYTemp {
   Voters_VotingPerformanceEvenYearPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearPrimary
   Voters_VotingPerformanceEvenYearGeneralAndPrimary String?  @db.Text()  // Voters_VotingPerformanceEvenYearGeneralAndPrimary
   Voters_VotingPerformanceMinorElection String?  @db.Text()  // Voters_VotingPerformanceMinorElection
+  General_2026 String?  @db.Text()  // General_2026
+  Primary_2026 String?  @db.Text()  // Primary_2026
+  OtherElection_2026 String?  @db.Text()  // OtherElection_2026
+  AnyElection_2025 String?  @db.Text()  // AnyElection_2025
+  General_2024 String?  @db.Text()  // General_2024
+  Primary_2024 String?  @db.Text()  // Primary_2024
+  PresidentialPrimary_2024 String?  @db.Text()  // PresidentialPrimary_2024
+  OtherElection_2024 String?  @db.Text()  // OtherElection_2024
+  AnyElection_2023 String?  @db.Text()  // AnyElection_2023
   General_2022 String?  @db.Text()  // General_2022
   Primary_2022 String?  @db.Text()  // Primary_2022
   OtherElection_2022 String?  @db.Text()  // OtherElection_2022


### PR DESCRIPTION
in dev:
```sql
select 
  "General_2026",
  "Primary_2026",
  "OtherElection_2026",
  "AnyElection_2025",
  "General_2024",
  "Primary_2024",
  "PresidentialPrimary_2024",
  "OtherElection_2024",
  "AnyElection_2023"
from "VoterAKTemp"
union
select 
  "General_2026",
  "Primary_2026",
  "OtherElection_2026",
  "AnyElection_2025",
  "General_2024",
  "Primary_2024",
  "PresidentialPrimary_2024",
  "OtherElection_2024",
  "AnyElection_2023"
from "VoterALTemp"
limit 100;
```
shows that the new columns, though currently `NULL`, were correctly added.